### PR TITLE
adding a repair for removing empty paragraphs, and cleanup unittest

### DIFF
--- a/test/test3.json
+++ b/test/test3.json
@@ -1,0 +1,180 @@
+{
+    "paragraphs": [
+      {
+        "text": "%md\n# Decision Trees Example\n<link rel=\"stylesheet\" href=\"https://doc.splicemachine.com/zeppelin/css/zepstyles2.css\" />\n\nThis notebook provides an example of implementing a *Decision Tree* algorithm that:\n\n* Loads a data file\n* Parses the data as an RDD of LabeledPoint\n* Performs classification using a decision tree with Gini impurity as an impurity measure and a maximum tree depth of 5.\n\nThe <a href=\"https://spark.apache.org/docs/latest/mllib-decision-tree.html\" target=\"_blank\">Decision Tree Algorithm</a> is a greedy algorithm that performs a recursive binary partitioning of the feature space for predictive modeling. Here are some interesting points about this algorithm: \n\n* Locally optimal decisions are made at each node in hopes of a globally optimal decision\n* Because of it's greedy nature, it cannot guarantee the globally optimal tree\n\nAt its core (and most simplified), decision trees are simply a system of if-else statements, always taking the most optimal answer, resulting in (hopefully) the most optimal decision, as shown in this diagram:\n\n<img class=\"splice\" src=\"http://mines.humanoriented.com/classes/2010/fall/csci568/portfolio_exports/lguo/image/decisionTree/classification.jpg\">",
+        "user": "anonymous",
+        "dateUpdated": "2018-12-01 07:13:03.558",
+        "config": {
+          "tableHide": false,
+          "editorSetting": {
+            "language": "markdown",
+            "editOnDblClick": true,
+            "completionSupport": false
+          },
+          "colWidth": 12.0,
+          "editorMode": "ace/mode/markdown",
+          "editorHide": true,
+          "fontSize": 9.0,
+          "results": {},
+          "enabled": false
+        },
+        "settings": {
+          "params": {},
+          "forms": {}
+        },
+        "results": {
+          "code": "SUCCESS",
+          "msg": [
+            {
+              "type": "HTML",
+              "data": "<div class=\"markdown-body\">\n<h1>Decision Trees</h1>\n<link rel=\"stylesheet\" href=\"https://doc.splicemachine.com/zeppelin/css/zepstyles2.css\" />\n<p>This notebook provides an example of implementing a <em>Decision Trees Example</em> algorithm that:</p>\n<ul>\n  <li>Loads a data file</li>\n  <li>Parses the data as an RDD of LabeledPoint</li>\n  <li>Performs classification using a decision tree with Gini impurity as an impurity measure and a maximum tree depth of 5.</li>\n</ul>\n<p>The <a href=\"https://spark.apache.org/docs/latest/mllib-decision-tree.html\" target=\"_blank\">Decision Tree Algorithm</a> is a greedy algorithm that performs a recursive binary partitioning of the feature space for predictive modeling. Here are some interesting points about this algorithm: </p>\n<ul>\n  <li>Locally optimal decisions are made at each node in hopes of a globally optimal decision</li>\n  <li>Because of it&rsquo;s greedy nature, it cannot guarantee the globally optimal tree</li>\n</ul>\n<p>At its core (and most simplified), decision trees are simply a system of if-else statements, always taking the most optimal answer, resulting in (hopefully) the most optimal decision, as shown in this diagram:</p>\n<img class=\"splice\" src=\"http://mines.humanoriented.com/classes/2010/fall/csci568/portfolio_exports/lguo/image/decisionTree/classification.jpg\">\n</div>"
+            }
+          ]
+        },
+        "apps": [],
+        "jobName": "paragraph_1542398443304_1947682620",
+        "id": "20170620-141909_771490751",
+        "dateCreated": "2018-11-16 12:00:43.000",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500
+      },
+      {
+        "text": "%md\n## Decision Tree Example\n\nThe example in the next paragraph loads a LIBSVM data file, available from <a href=\"https://github.com/apache/spark/blob/master/data/mllib/sample_libsvm_data.txt\" target=\"_blank\">https://github.com/apache/spark/blob/master/data/mllib/sample_libsvm_data.txt</a>.\n\nIt then parses that data as an RDD of labeled points, and performs classification using a decision tree with Gini impurity as an impurity measure and a maximum tree depth of 5. The test error is calculated, to measure the accuracy of the algorithm.\n\nYou can learn more about decision trees with MLlib on <a href=\"https://spark.apache.org/docs/latest/mllib-decision-tree.html\" target=\"_blank\">Spark's Decision Tree page</a>.",
+        "user": "anonymous",
+        "dateUpdated": "2018-12-01 07:13:09.994",
+        "config": {
+          "colWidth": 12.0,
+          "fontSize": 9.0,
+          "enabled": false,
+          "results": {},
+          "editorSetting": {
+            "language": "markdown",
+            "editOnDblClick": true,
+            "completionKey": "TAB",
+            "completionSupport": false
+          },
+          "editorMode": "ace/mode/markdown",
+          "editorHide": true,
+          "tableHide": false
+        },
+        "settings": {
+          "params": {},
+          "forms": {}
+        },
+        "results": {
+          "code": "SUCCESS",
+          "msg": [
+            {
+              "type": "HTML",
+              "data": "<div class=\"markdown-body\">\n<h2>Decision Tree Example</h2>\n<p>The example in the next paragraph loads a LIBSVM data file, available from <a href=\"https://github.com/apache/spark/blob/master/data/mllib/sample_libsvm_data.txt\" target=\"_blank\"><a href=\"https://github.com/apache/spark/blob/master/data/mllib/sample_libsvm_data.txt\">https://github.com/apache/spark/blob/master/data/mllib/sample_libsvm_data.txt</a></a>.</p>\n<p>It then parses that data as an RDD of labeled points, and performs classification using a decision tree with Gini impurity as an impurity measure and a maximum tree depth of 5. The test error is calculated, to measure the accuracy of the algorithm.</p>\n<p>You can learn more about decision trees with MLlib on <a href=\"https://spark.apache.org/docs/latest/mllib-decision-tree.html\" target=\"_blank\">Spark&rsquo;s Decision Tree page</a>.</p>\n</div>"
+            }
+          ]
+        },
+        "apps": [],
+        "jobName": "paragraph_1542767864123_962201816",
+        "id": "20181120-183744_1917061299",
+        "dateCreated": "2018-11-20 18:37:44.123",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500
+      },
+      {
+        "text": "%spark\nimport org.apache.spark.mllib.tree.DecisionTree\nimport org.apache.spark.mllib.tree.model.DecisionTreeModel\nimport org.apache.spark.mllib.util.MLUtils\n\n// Load and parse the data file.\nval data = MLUtils.loadLibSVMFile(sc, \"/opt/data/sample_libsvm_data.txt\")\n// Split the data into training and test sets (30% held out for testing)\nval splits = data.randomSplit(Array(0.7, 0.3))\nval (trainingData, testData) = (splits(0), splits(1))\n\n// Train a DecisionTree model.\n//  Empty categoricalFeaturesInfo indicates all features are continuous.\nval numClasses = 2\nval categoricalFeaturesInfo = Map[Int, Int]()\nval impurity = \"gini\"\nval maxDepth = 5\nval maxBins = 32\n\nval model = DecisionTree.trainClassifier(trainingData, numClasses, categoricalFeaturesInfo,\n  impurity, maxDepth, maxBins)\n\n// Evaluate model on test instances and compute test error\nval labelAndPreds = testData.map { point =>\n  val prediction = model.predict(point.features)\n  (point.label, prediction)\n}\nval testErr = labelAndPreds.filter(r => r._1 != r._2).count().toDouble / testData.count()\nprintln(\"Test Error = \" + testErr)\nprintln(\"Learned classification tree model:\\n\" + model.toDebugString)\n",
+        "user": "anonymous",
+        "dateUpdated": "2018-12-03 04:32:10.161",
+        "config": {
+          "editorSetting": {
+            "language": "scala",
+            "editOnDblClick": false,
+            "completionKey": "TAB",
+            "completionSupport": true
+          },
+          "colWidth": 12.0,
+          "editorMode": "ace/mode/scala",
+          "fontSize": 9.0,
+          "results": {},
+          "enabled": true,
+          "tableHide": false
+        },
+        "settings": {
+          "params": {},
+          "forms": {}
+        },
+        "apps": [],
+        "jobName": "paragraph_1542398443305_2007728913",
+        "id": "20170620-153325_126659046",
+        "dateCreated": "2018-11-16 12:00:43.000",
+        "status": "READY",
+        "errorMessage": "",
+        "progressUpdateIntervalMs": 500
+      },
+      {
+        "text": "%md\n## Where to Go Next\n\nThe next notebook in this class shows you an example of implementing a simple [*ETL Pipeline Example*](/#/notebook/2DWVX87QY) in a Splice Machine Zeppelin notebook.\n",
+        "user": "anonymous",
+        "dateUpdated": "2018-12-12 02:12:36.887",
+        "config": {
+          "editorSetting": {
+            "language": "markdown",
+            "editOnDblClick": true,
+            "completionKey": "TAB",
+            "completionSupport": false
+          },
+          "colWidth": 12.0,
+          "editorMode": "ace/mode/markdown",
+          "fontSize": 9.0,
+          "results": {},
+          "enabled": false,
+          "editorHide": true,
+          "tableHide": false
+        },
+        "settings": {
+          "params": {},
+          "forms": {}
+        },
+        "results": {
+          "code": "SUCCESS",
+          "msg": [
+            {
+              "type": "HTML",
+              "data": "<div class=\"markdown-body\">\n<h2>Where to Go Next</h2>\n<p>The next notebook in this class shows you an example of implementing a simple <a href=\"/#/notebook/2DWVX87QY\"><em>ETL Pipeline Example</em></a> in a Splice Machine Zeppelin notebook.</p>\n</div>"
+            }
+          ]
+        },
+        "apps": [],
+        "jobName": "paragraph_1542398443306_-1240311123",
+        "id": "20170620-153620_626385294",
+        "dateCreated": "2018-11-16 12:00:43.000",
+        "dateStarted": "2018-12-12 02:12:36.887",
+        "dateFinished": "2018-12-12 02:12:36.900",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500
+      },
+      {
+        "user": "anonymous",
+        "config": {},
+        "settings": {
+          "params": {},
+          "forms": {}
+        },
+        "apps": [],
+        "jobName": "paragraph_1544580748903_418431993",
+        "id": "20181212-021228_191417245",
+        "dateCreated": "2018-12-12 02:12:28.904",
+        "status": "READY",
+        "progressUpdateIntervalMs": 500
+      }
+    ],
+    "name": "Splice Machine Training / For Data Scientists / h. Decision Trees Example",
+    "id": "2DUQ8F96K",
+    "noteParams": {},
+    "noteForms": {},
+    "angularObjects": {
+      "md:shared_process": [],
+      "splicemachine:shared_process": []
+    },
+    "config": {
+      "isZeppelinNotebookCronEnable": false,
+      "looknfeel": "default",
+      "personalizedMode": "false"
+    },
+    "info": {}
+  }

--- a/test/test_apply_paragraph_standards.py
+++ b/test/test_apply_paragraph_standards.py
@@ -21,17 +21,19 @@ class Test_TestRepairParagraphBlocks(unittest.TestCase):
                 'has_changes': False,
                 'para_count': 1,
                 'notebook_id': "2TESTPGDOC",
-                'status': 0
+                'status': 0,
+                'empty_paragraph': False
             }
-            apply_paragraph_standards.repair_other_paragraph_block(notebook_paragraph, tracking)
-            self.assertEqual(notebook_paragraph['config'].get('editorHide', False), False)
-            self.assertEqual(notebook_paragraph['config'].get('tableHide', False), False)
-            self.assertEqual(notebook_paragraph['config'].get('enabled', False), True)
-            self.assertEqual(notebook_paragraph['results'].get('msg', False), False)
-            self.assertEqual(notebook_paragraph.get('dateStarted', False), False)
-            self.assertEqual(notebook_paragraph.get('dateFinished', False), False)
+            apply_paragraph_standards.repair_other_paragraph_block(
+                notebook_paragraph, tracking)
+            self.assertFalse(notebook_paragraph['config'].get('editorHide', True))
+            self.assertFalse(notebook_paragraph['config'].get('tableHide', True))
+            self.assertTrue(notebook_paragraph['config'].get('enabled', False))
+            self.assertFalse(notebook_paragraph['results'].get('msg', False))
+            self.assertFalse(notebook_paragraph.get('dateStarted', False))
+            self.assertFalse(notebook_paragraph.get('dateFinished', False))
             self.assertEqual(notebook_paragraph.get('status', ''), 'READY')
-            self.assertEqual(tracking['has_changes'], True)
+            self.assertTrue(tracking['has_changes'])
 
     # Run the following tests:
     #  - Enabled Run Button
@@ -48,18 +50,20 @@ class Test_TestRepairParagraphBlocks(unittest.TestCase):
                 'has_changes': False,
                 'para_count': 1,
                 'notebook_id': "2TESTPGDOC",
-                'status': 0
+                'status': 0,
+                'empty_paragraph': False
             }
             # get our standards exceptions loaded
             with open("./test/test_empty_exceptions.yaml", 'r') as stream:
                 sanity_exceptions = yaml.load(stream)
 
-            apply_paragraph_standards.repair_md_paragraph_block(notebook_paragraph, tracking, sanity_exceptions)
-            self.assertEqual(notebook_paragraph['config'].get('editorHide', False), True)
-            self.assertEqual(notebook_paragraph['config'].get('tableHide', False), False)
-            self.assertEqual(notebook_paragraph['config'].get('enabled', False), False)
+            apply_paragraph_standards.repair_md_paragraph_block(
+                notebook_paragraph, tracking, sanity_exceptions)
+            self.assertTrue(notebook_paragraph['config'].get('editorHide', False))
+            self.assertFalse(notebook_paragraph['config'].get('tableHide', False))
+            self.assertFalse(notebook_paragraph['config'].get('enabled', False))
             self.assertEqual(notebook_paragraph.get('status', ''), 'FINISHED')
-            self.assertEqual(tracking['has_changes'], True)
+            self.assertTrue(tracking['has_changes'])
 
     # Run the following tests:
     #  - Pass in an override for the EditorOpen
@@ -73,7 +77,8 @@ class Test_TestRepairParagraphBlocks(unittest.TestCase):
                 'has_changes': False,
                 'para_count': 1,
                 'notebook_id': "2TESTPGDOC",
-                'status': 0
+                'status': 0,
+                'empty_paragraph': False
             }
             # get our standards exceptions loaded
             with open("./test/test_exceptions.yaml", 'r') as stream:
@@ -82,6 +87,29 @@ class Test_TestRepairParagraphBlocks(unittest.TestCase):
             apply_paragraph_standards.repair_md_paragraph_block(notebook_paragraph, tracking, sanity_exceptions)
             self.assertEqual(notebook_paragraph['config'].get('editorHide', False), False)
             self.assertEqual(tracking['has_changes'], True)
+
+    # Run the following tests:
+    #  - Empty Paragraph - This is the LAST paragraph in test3.json
+    def test_paragraph_block_test4(self):
+        with open('./test/test3.json', 'r') as file_handler:
+            data = json.load(file_handler)
+            notebook_paragraph = data['paragraphs'][-1]
+            tracking = {
+                'modify': True,
+                'tests': 'Repair',
+                'has_changes': False,
+                'para_count': 1,
+                'notebook_id': "2TESTPGDOC",
+                'status': 0,
+                'empty_paragraph': False
+            }
+            # get our standards exceptions loaded
+            with open("./test/test_exceptions.yaml", 'r') as stream:
+                sanity_exceptions = yaml.load(stream)
+
+            apply_paragraph_standards.process_paragraph(
+                notebook_paragraph, tracking, sanity_exceptions)
+            self.assertTrue(tracking['empty_paragraph'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Apache Zeppelin sometimes drops an empty paragraph at the bottom of a notebook.  I've added code to detect any paragraphs without a 'text' field, and remove them prior to write back to disk.  

I also cleaned up the unittest asserts to more appropriate assert types.